### PR TITLE
Aligned classification of glycine to apolar to match Rosetta

### DIFF
--- a/functions/pyrosetta_utils.py
+++ b/functions/pyrosetta_utils.py
@@ -90,7 +90,7 @@ def score_interface(pdb_file, binder_chain="B", use_pyrosetta=True):
     interface_residues_pdb_ids_str = ','.join(interface_residues_pdb_ids)
 
     # Calculate the percentage of hydrophobic residues at the interface of the binder
-    hydrophobic_aa = set('ACFILMPVWY')
+    hydrophobic_aa = set('ACFGILMPVWY')
     hydrophobic_count = sum(interface_AA[aa] for aa in hydrophobic_aa)
     if interface_nres != 0:
         interface_hydrophobicity = (hydrophobic_count / interface_nres) * 100


### PR DESCRIPTION
Changed classification of glycine to apolar to match Rosetta definition in pr_alternative_utils.py for surface_hydrophobicity as well as interface_hydrophobicity. Also adjusted pyrosetta_utils.py to include glycine as hydrophobic in interface_hydrophobicity (not an active filter, but to maintain consistency). 

Re-arranged pr_alternative_utils.py for readability.