### PR TITLE
Prevent openMM from linking separate chains in concatenated structure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ BindCraft-main-v1.5.code-workspace
 **/__pycache__/
 **/FASPR-master/
 *.cc
+**/ColabDesign-main/

--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ If you run BindCraft without `--settings` in a terminal (TTY) or pass `--interac
 You can further control runtime behavior with these flags:
 
 - `--verbose`: Enable detailed timing/progress logs for BindCraft internals.
+- '--debug-pdbs': Write intermediate PDBs from OpenMM relax (`.debug_deconcat.pdb`, `.debug_pdbfixer.pdb`, `.debug_post_initial_relax.pdb`, `.debug_post_faspr.pdb`)
 - `--no-plots`: Disable saving design trajectory plots (overrides advanced settings).
 - `--no-animations`: Disable saving trajectory animations (overrides advanced settings).
 

--- a/bindcraft.py
+++ b/bindcraft.py
@@ -78,6 +78,8 @@ parser.add_argument('--no-pyrosetta', action='store_true',
                     help='Run without PyRosetta (skips relaxation and PyRosetta-based scoring)')
 parser.add_argument('--verbose', action='store_true',
                     help='Enable detailed timing/progress logs')
+parser.add_argument('--debug-pdbs', action='store_true',
+                    help='Write intermediate debug PDBs during OpenMM relax (deconcat, PDBFixer, post-initial-relax, post-FASPR)')
 parser.add_argument('--no-plots', action='store_true',
                     help='Disable saving design trajectory plots (overrides advanced settings)')
 parser.add_argument('--no-animations', action='store_true',
@@ -439,10 +441,11 @@ settings_file = os.path.basename(settings_path).split('.')[0]
 filters_file = os.path.basename(filters_path).split('.')[0]
 advanced_file = os.path.basename(advanced_path).split('.')[0]
 
-# Provide context to OpenMM relax for de-concatenation/re-concatenation
+# Provide context to OpenMM relax for de-concatenation/re-concatenation and debug PDBs
 try:
     os.environ['BINDCRAFT_STARTING_PDB'] = os.path.abspath(os.path.expanduser(target_settings["starting_pdb"]))
     os.environ['BINDCRAFT_TARGET_CHAINS'] = str(target_settings.get("chains", "A"))
+    os.environ['BINDCRAFT_DEBUG_PDBS'] = '1' if args.debug_pdbs else '0'
 except Exception:
     pass
 

--- a/bindcraft.py
+++ b/bindcraft.py
@@ -439,6 +439,13 @@ settings_file = os.path.basename(settings_path).split('.')[0]
 filters_file = os.path.basename(filters_path).split('.')[0]
 advanced_file = os.path.basename(advanced_path).split('.')[0]
 
+# Provide context to OpenMM relax for de-concatenation/re-concatenation
+try:
+    os.environ['BINDCRAFT_STARTING_PDB'] = os.path.abspath(os.path.expanduser(target_settings["starting_pdb"]))
+    os.environ['BINDCRAFT_TARGET_CHAINS'] = str(target_settings.get("chains", "A"))
+except Exception:
+    pass
+
 ### load AF2 model settings
 design_models, prediction_models, multimer_validation = load_af2_models(advanced_settings["use_multimer_design"])
 

--- a/bindcraft.py
+++ b/bindcraft.py
@@ -269,6 +269,11 @@ def _prompt_interactive_and_prepare_args(args):
         plots_on = _yes_no("Enable saving plots?", default_yes=True)
         animations_on = _yes_no("Enable saving animations?", default_yes=True)
         run_with_pyrosetta = _yes_no("Run with PyRosetta?", default_yes=True)
+        
+        # Only ask about debug PDbs if not using PyRosetta (since debug PDbs are for OpenMM relax)
+        debug_pdbs = False
+        if not run_with_pyrosetta:
+            debug_pdbs = _yes_no("Write intermediate debug PDBs during OpenMM relax?", default_yes=False)
 
         # Container selection BEFORE final confirmation
         container_plan = {k: None for k in container_plan}  # reset plan
@@ -327,6 +332,8 @@ def _prompt_interactive_and_prepare_args(args):
         print(f"Filter Setting: {os.path.splitext(os.path.basename(selected_filter))[0]}")
         print(f"Advanced Setting: {os.path.splitext(os.path.basename(selected_advanced))[0]}")
         print(f"Verbose: {'Yes' if verbose else 'No'}")
+        if not run_with_pyrosetta:
+            print(f"Debug PDbs: {'Yes' if debug_pdbs else 'No'}")
         print(f"Plots: {'On' if plots_on else 'Off'}")
         print(f"Animations: {'On' if animations_on else 'Off'}")
         print(f"PyRosetta: {'On' if run_with_pyrosetta else 'Off'}")
@@ -366,6 +373,7 @@ def _prompt_interactive_and_prepare_args(args):
     args.filters = selected_filter
     args.advanced = selected_advanced
     args.verbose = verbose
+    args.debug_pdbs = debug_pdbs
     args.no_plots = (not plots_on)
     args.no_animations = (not animations_on)
     args.no_pyrosetta = (not run_with_pyrosetta)
@@ -395,6 +403,8 @@ def _prompt_interactive_and_prepare_args(args):
             docker_cmd.append("--no-pyrosetta")
         if args.verbose:
             docker_cmd.append("--verbose")
+        if args.debug_pdbs:
+            docker_cmd.append("--debug-pdbs")
         if args.no_plots:
             docker_cmd.append("--no-plots")
         if args.no_animations:

--- a/functions/biopython_utils.py
+++ b/functions/biopython_utils.py
@@ -631,6 +631,7 @@ def split_chain_into_subchains(pdb_in_path: str,
         lengths = [int(x) for x in subchain_lengths if int(x) > 0]
         chain_names = [str(x) for x in new_chain_ids]
         if not lengths or len(lengths) != len(chain_names):
+            vprint(f"[BioPDB] split_chain_into_subchains: invalid lengths/ids (len(lengths)={len(lengths)}, len(ids)={len(chain_names)})")
             return
 
         with open(pdb_in_path, 'r') as fin:
@@ -674,7 +675,8 @@ def split_chain_into_subchains(pdb_in_path: str,
         out_path = output_path if output_path else pdb_in_path
         with open(out_path, 'w') as fout:
             fout.writelines(out_lines)
-    except Exception:
+    except Exception as e:
+        vprint(f"[BioPDB] split_chain_into_subchains failed: {e}")
         return
 
 

--- a/functions/generic_utils.py
+++ b/functions/generic_utils.py
@@ -357,7 +357,10 @@ def save_fasta(design_name, sequence, design_paths):
 def clean_pdb(pdb_file):
     # Read the pdb file and filter relevant lines
     with open(pdb_file, 'r') as f_in:
-        relevant_lines = [line for line in f_in if line.startswith(('ATOM', 'HETATM', 'MODEL', 'TER', 'END', 'LINK'))]
+        relevant_lines = [
+            line for line in f_in
+            if line.startswith(('ATOM', 'HETATM', 'MODEL', 'TER', 'END', 'LINK', 'CONECT', 'SSBOND'))
+        ]
 
     # Write the cleaned lines back to the original pdb file
     with open(pdb_file, 'w') as f_out:


### PR DESCRIPTION
When target PDB has more than one chain, colabdesign concatenates al the target chains into Chain A. OpenMM inappropriately treats the chains as continuous and links them, distorting the structures.. This also occurs when there are discontinuous segments in a singe chain. To resolve this issue, PDB structures are now de-concatenated prior to openMM relax functions, so each chain (including discontinuous segments of a single chain) is provided with a distinct chain ID (starting with C). After relaxation, the PDB file is then re-concatenated for downstream scoring and analysis.